### PR TITLE
copy button added #38

### DIFF
--- a/Collab-Chat-App/client/src/App.css
+++ b/Collab-Chat-App/client/src/App.css
@@ -46,6 +46,7 @@ body {
   background: #12243ceb;
   padding: 0px 30px 30px 30px;
   border-radius: 20px;
+  /* text-align: center; */
 }
 .box2 {
   display: flex;
@@ -435,3 +436,15 @@ p {
     margin-top: 30px;
   }
 }
+
+/* copy to clipboard button Css */
+img { 
+  max-width: 25%;
+}
+.copy-icon {
+  padding: 30% 5% 3% 0 ;
+  margin: 5% 10% 5% 0%;
+}
+ .roomcode button:hover {
+  background: #152b7e;
+ }

--- a/Collab-Chat-App/client/src/App.js
+++ b/Collab-Chat-App/client/src/App.js
@@ -51,7 +51,10 @@ function App() {
 
                 <div className="roomcode">
                   <p className="room-id">{room}</p>
-                  <button onClick={createid}>Generate</button>
+                  <button title="Click to Copy" onClick={() => { navigator.clipboard.writeText(room) }}>
+                    <span className="copy-icon">Copy</span>
+                    <img src="http://clipground.com/images/copy-4.png" />
+                  </button>
                 </div>
               </div>
               <div className="box2">


### PR DESCRIPTION
When the website renders or refreshes, a new room id is produced, and next to it is a copy button that copies the room id to the clipboard. I have now removed the generate button.